### PR TITLE
Allow the installation of phpcs on modern versions of composer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:alpine3.14
 
 RUN apk --no-cache add jq git
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.4.4 /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_HOME=/root/.composer
 ENV COMPOSER_ALLOW_SUPERUSER 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,14 @@ RUN apk --no-cache add jq git
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_HOME=/root/.composer
-
 ENV COMPOSER_ALLOW_SUPERUSER 1
-
 ENV COMPOSER_NO_INTERACTION 1
 
+# Allow running plugins for this specific package
+# See https://github.com/PHPCSStandards/composer-installer#usage
+RUN composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+
+# Install phpcs
 RUN composer global require --dev \
     "squizlabs/php_codesniffer" \
     "dealerdirect/phpcodesniffer-composer-installer" \
@@ -19,8 +22,8 @@ RUN composer global require --dev \
 
 ENV PATH $PATH:$COMPOSER_HOME/vendor/bin
 
+# Install reviewdog
 ENV REVIEWDOG_VERSION=v0.13.1
-
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Hi @shirobrak 

As you can see in https://github.com/PHPCSStandards/composer-installer#usage you need to explicitly allow the running of plugin hook code in modern versions of composer. This PR does two things:

- Lock composer to a predictable version (just like you did for the Alpine base image and Reviewdog)
- Allow plugin hooks for the `dealerdirect/phpcodesniffer-composer-installer` composer package (which fails otherwise)

Thanks for your work!