### PR TITLE
chore(deps): update reviewdog to 0.14.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN composer global require --dev \
 
 ENV PATH $PATH:$COMPOSER_HOME/vendor/bin
 
-ENV REVIEWDOG_VERSION=v0.13.1
+ENV REVIEWDOG_VERSION=v0.14.1
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 


### PR DESCRIPTION
Fixes `failed to run 'git rev-parse --show-prefix': exit status 128`.

(https://github.com/reviewdog/reviewdog/issues/1158)